### PR TITLE
Fix infinite loop on CPC endpoint read failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,4 @@ all: ezspd
 .PHONY: clean
 
 clean:
-	rm -f ezspd
+	rm -f ezspd main.o ash.o

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=
+CFLAGS=-Wall
 LDFLAGS=
 LIBS=-lcpc
 

--- a/main.c
+++ b/main.c
@@ -176,7 +176,7 @@ static int read_socket(int socket_fd, uint8_t *ash_buf, uint8_t *ezsp_buf)
 		printf("Connection closed, exiting.\n");
 		return -1;
 	}
-	debug_printf("socket -> radio %d bytes\n", count);
+	debug_printf("socket -> radio %ld bytes\n", count);
 	print_data(ash_buf, count);
 
 	tmp = ash_buf;
@@ -203,6 +203,8 @@ static int read_socket(int socket_fd, uint8_t *ash_buf, uint8_t *ezsp_buf)
 		tmp++;
 		count--;
 	}
+
+	return 0;
 }
 
 /*
@@ -224,7 +226,7 @@ static void read_cpc(int socket_fd, uint8_t *ash_buf, uint8_t *ezsp_buf)
 		exit(EXIT_FAILURE);
 	}
 
-	debug_printf("radio -> socket %d bytes\n", count);
+	debug_printf("radio -> socket %ld bytes\n", count);
 	print_data(ezsp_buf, count);
 	count = ash_encode_data_frame(ezsp_buf, count, ash_buf);
 	print_data(ash_buf, count);

--- a/main.c
+++ b/main.c
@@ -219,7 +219,7 @@ static void read_cpc(int socket_fd, uint8_t *ash_buf, uint8_t *ezsp_buf)
 
 	count = cpc_read_endpoint(zigbee_cpc_endpoint,
 				  ezsp_buf, EZSP_BUFFER_SIZE, SL_CPC_FLAG_NON_BLOCK);
-	if (ret < 0) {
+	if (count < 0) {
 		perror("Error reading from CPC\n");
 		exit(EXIT_FAILURE);
 	}


### PR DESCRIPTION
`ret < 0` is used to detect when the read from the CPC endpoint fails, but `ret` is never assigned.

https://github.com/agners/silabs-cpc-ezspd/blob/680bd9e8f678a54ba9c17b62f1888c2864f97dd5/main.c#L220-L222

I've fixed the problem and enabled compiler warnings in the Makefile to catch this type of bug in the future.

This unfortunately doesn't fix the underlying firmware problem but it does clean up the debug log and hopefully point to the underlying problem (I suspect it may be reconnect issue with `cpcd` and something related to manufacturer token reading with the alpha EmberZNet).